### PR TITLE
ok-dspace: deploy automatically, pull-based from main

### DIFF
--- a/.github/workflows/pin-ok-dspace.yml
+++ b/.github/workflows/pin-ok-dspace.yml
@@ -48,11 +48,6 @@ permissions:
 env:
   OVERLAY: overlays/kosarko-ns
   PUBLIC_URL: https://ok-dspace.dyn.cloud.e-infra.cz
-  YQ_VERSION: v4.53.3
-  # SHA-256 of yq_linux_amd64 for YQ_VERSION, from that release's own
-  # `checksums` asset. Update BOTH together - a version bump with a stale
-  # checksum fails the install step, which is the intended behaviour.
-  YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
 
 jobs:
   pin:
@@ -74,24 +69,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-
-      # Kept even though ubuntu-latest ships a yq, because the VERSION is the
-      # point: the overlay was pre-normalised to v4.53.3's exact output so that
-      # every generated commit is a clean one-line tag change. A different yq
-      # could reformat the whole file on the first write.
-      - name: Install yq
-        run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/bin"
-          curl -fsSL -o "${RUNNER_TEMP}/bin/yq" \
-            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-          # This job holds contents:write on the repository, so an unverified
-          # binary fetched over the network would be arbitrary code execution
-          # with permission to commit to main. Pinning the version alone does
-          # not help: release assets can be replaced.
-          echo "${YQ_SHA256}  ${RUNNER_TEMP}/bin/yq" | sha256sum -c -
-          chmod +x "${RUNNER_TEMP}/bin/yq"
-          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
 
       - name: Resolve requested image tags
         id: resolve
@@ -210,6 +187,14 @@ jobs:
           # overlay was pre-normalised to yq's canonical form in a reviewed
           # commit. The property being relied on is COMMENT PRESERVATION, not
           # "leaves the file alone".
+          #
+          # yq comes preinstalled on ubuntu-latest (4.53.3 today, the version
+          # the overlay was normalised with). If a future runner image ships a
+          # yq that formats differently, the first pin after that carries a
+          # whole-file reformat instead of a one-line tag change - cosmetic,
+          # renders identically, and self-correcting from the next pin on.
+          # Deliberately not guarded: a version assertion would turn a tidy
+          # diff into a failed deploy.
           #
           # Each dispatch rewrites ONLY its own component's tag. That is what
           # stops a backend deploy from reasserting a stale frontend tag.

--- a/.github/workflows/pin-ok-dspace.yml
+++ b/.github/workflows/pin-ok-dspace.yml
@@ -1,0 +1,317 @@
+# Pins the image tags the ok-dspace test environment should run, and commits
+# them to `main`.
+#
+# THIS WORKFLOW DOES NOT TOUCH THE CLUSTER. It records desired state in git;
+# the in-cluster CronJob in ci-reconcile/ notices and applies it, and
+# verify-ok-dspace.yml confirms the result over the public URL. That split is
+# what keeps every cluster credential out of GitHub and every GitHub credential
+# out of the cluster - see ci-reconcile/README.md.
+#
+# Triggered manually, or by repository_dispatch from the Docker image builds in
+# ufal/clarin-dspace and ufal/dspace-angular (see their docker.yml).
+#
+# DELIBERATELY has no `on: push` trigger: it commits to main, and a push
+# trigger would make it re-trigger itself.
+name: Pin ok-dspace image tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_tag:
+        description: "Tag for ufal/dspace + ufal/dspace-solr (blank = keep the committed tag)"
+        required: false
+        type: string
+      frontend_tag:
+        description: "Tag for ufal/dspace-angular (blank = keep the committed tag)"
+        required: false
+        type: string
+  repository_dispatch:
+    types: [deploy-ok-dspace]
+
+# Serialize: two dispatches must never race to push to main.
+#
+# KNOWN TRADEOFF, chosen deliberately. The group is shared across both
+# components, and GitHub keeps at most one running + one pending run per group -
+# a newly queued run cancels the pending one. So three overlapping runs (each up
+# to ~35m because `verify` is in the same workflow) can cancel a middle pin,
+# which then silently never happens until that component is pushed again.
+# Per-component groups would fix that, but they reintroduce the concurrent-push
+# race on main that this group exists to prevent. Shared is the safer default at
+# this deploy frequency; revisit if pins ever overlap in practice.
+concurrency:
+  group: pin-ok-dspace
+  cancel-in-progress: false
+
+permissions:
+  contents: write # commit the resolved image tag back to main
+
+env:
+  OVERLAY: overlays/kosarko-ns
+  PUBLIC_URL: https://ok-dspace.dyn.cloud.e-infra.cz
+  YQ_VERSION: v4.53.3
+
+jobs:
+  pin:
+    if: github.repository == 'ufal/dspace-k8s'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Consumed by the verify job below.
+    outputs:
+      backend_tag: ${{ steps.resolve.outputs.backend_tag }}
+      frontend_tag: ${{ steps.resolve.outputs.frontend_tag }}
+      # Empty unless the tag is a commit sha - see `resolve`.
+      backend_sha: ${{ steps.resolve.outputs.backend_sha }}
+      frontend_sha: ${{ steps.resolve.outputs.frontend_sha }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      # Kept even though ubuntu-latest ships a yq, because the VERSION is the
+      # point: the overlay was pre-normalised to v4.53.3's exact output so that
+      # every generated commit is a clean one-line tag change. A different yq
+      # could reformat the whole file on the first write.
+      - name: Install yq
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL -o "${RUNNER_TEMP}/bin/yq" \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          chmod +x "${RUNNER_TEMP}/bin/yq"
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
+      - name: Resolve requested image tags
+        id: resolve
+        env:
+          # Passed through the environment rather than interpolated straight
+          # into the script: client_payload is external input.
+          EVENT_NAME: ${{ github.event_name }}
+          PAYLOAD_COMPONENT: ${{ github.event.client_payload.component }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha }}
+          INPUT_BACKEND_TAG: ${{ inputs.backend_tag }}
+          INPUT_FRONTEND_TAG: ${{ inputs.frontend_tag }}
+        run: |
+          set -euo pipefail
+          BACKEND_TAG=""
+          FRONTEND_TAG=""
+
+          if [ "${EVENT_NAME}" = "repository_dispatch" ]; then
+            case "${PAYLOAD_COMPONENT}" in
+              backend)  BACKEND_TAG="${PAYLOAD_SHA}" ;;
+              frontend) FRONTEND_TAG="${PAYLOAD_SHA}" ;;
+              *)
+                echo "::error::unknown client_payload.component: '${PAYLOAD_COMPONENT}' (expected backend|frontend)"
+                exit 1 ;;
+            esac
+          else
+            BACKEND_TAG="${INPUT_BACKEND_TAG}"
+            FRONTEND_TAG="${INPUT_FRONTEND_TAG}"
+          fi
+
+          # Reject anything that is not a plausible tag before it reaches yq
+          # or curl.
+          for t in "${BACKEND_TAG}" "${FRONTEND_TAG}"; do
+            if [ -n "$t" ] && ! printf '%s' "$t" | grep -qE '^[A-Za-z0-9._-]{1,128}$'; then
+              echo "::error::refusing malformed image tag: '$t'"
+              exit 1
+            fi
+          done
+
+          # A tag is not necessarily a commit sha: `workflow_dispatch` accepts
+          # any image tag, and main currently pins a branch-name tag. Only a
+          # sha can be checked against what the deployed app reports, so emit
+          # these separately - verify gates on the sha outputs and falls back
+          # to a reachability-only check when they are empty. Passing a
+          # branch-name tag through would fail verify's sha validation and turn
+          # a perfectly good deploy red.
+          # Full 40 hex only, NOT verify's {7,40}. An all-hex short tag - a date
+          # like `20260722` is the realistic one - would otherwise classify as a
+          # sha, and verify would then poll 35 minutes for a commit that does
+          # not exist and fail a perfectly good deploy. `github.sha` is always
+          # 40 chars and a human pinning a sha pastes the whole thing, so
+          # nothing legitimate is lost here. Verify keeps {7,40} because a short
+          # sha is a reasonable thing to type into ITS dispatch form.
+          sha_or_empty() {
+            printf '%s' "$1" | grep -qE '^[0-9a-fA-F]{40}$' && printf '%s' "$1" || true
+          }
+
+          {
+            echo "backend_tag=${BACKEND_TAG}"
+            echo "frontend_tag=${FRONTEND_TAG}"
+            echo "backend_sha=$(sha_or_empty "${BACKEND_TAG}")"
+            echo "frontend_sha=$(sha_or_empty "${FRONTEND_TAG}")"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: backend='${BACKEND_TAG}' frontend='${FRONTEND_TAG}'"
+
+      - name: Verify the requested tags exist on Docker Hub
+        if: steps.resolve.outputs.backend_tag != '' || steps.resolve.outputs.frontend_tag != ''
+        env:
+          BACKEND_TAG: ${{ steps.resolve.outputs.backend_tag }}
+          FRONTEND_TAG: ${{ steps.resolve.outputs.frontend_tag }}
+        run: |
+          set -euo pipefail
+          # A fast-fail convenience, not the load-bearing guard - `verify` is
+          # that. On the dispatch path the image exists by construction, so this
+          # really only catches typos in a manual dispatch, ~30 minutes earlier
+          # than verify would. It can also fail a good deploy on a Docker Hub
+          # rate limit: delete it rather than work around it if that bites.
+          check() {
+            repo="$1"; tag="$2"
+            token="$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" | jq -r .token)"
+            if curl -fsSL -o /dev/null -I \
+                 -H "Authorization: Bearer ${token}" \
+                 -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                 -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+                 -H "Accept: application/vnd.oci.image.index.v1+json" \
+                 -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+                 "https://registry-1.docker.io/v2/${repo}/manifests/${tag}"; then
+              echo "  OK  ${repo}:${tag}"
+            else
+              echo "::error::${repo}:${tag} does not exist on Docker Hub - refusing to pin it"
+              exit 1
+            fi
+          }
+          if [ -n "${BACKEND_TAG}" ]; then
+            check ufal/dspace      "${BACKEND_TAG}"
+            check ufal/dspace-solr "${BACKEND_TAG}"
+          fi
+          if [ -n "${FRONTEND_TAG}" ]; then
+            check ufal/dspace-angular "${FRONTEND_TAG}"
+          fi
+
+      - name: Pin the tags in the overlay
+        id: pin
+        env:
+          BACKEND_TAG: ${{ steps.resolve.outputs.backend_tag }}
+          FRONTEND_TAG: ${{ steps.resolve.outputs.frontend_tag }}
+        run: |
+          set -euo pipefail
+          # yq, not `kustomize edit set image`: the latter drops the comments
+          # documenting the overlay. Note that yq reformats too - it strips
+          # blank lines and normalises inline comment spacing - which is why the
+          # overlay was pre-normalised to yq's canonical form in a reviewed
+          # commit. The property being relied on is COMMENT PRESERVATION, not
+          # "leaves the file alone".
+          #
+          # Each dispatch rewrites ONLY its own component's tag. That is what
+          # stops a backend deploy from reasserting a stale frontend tag.
+          set_tag() {
+            name="$1"; tag="$2"
+            # yq exits 0 and writes nothing when the selector matches nothing,
+            # so a renamed or removed `images:` entry would silently disable
+            # this workflow: no diff, changed=false, and the run goes green
+            # reporting "already at the requested version". Assert the key
+            # exists first. The names are kustomize selector keys from
+            # ../../k8s (`dataquest/*`), not the `ufal/*` image names, which is
+            # exactly why this is easy to get wrong.
+            n="$(NAME="$name" yq '[.images[] | select(.name == strenv(NAME))] | length' \
+                 "${OVERLAY}/kustomization.yaml")"
+            if [ "$n" != 1 ]; then
+              echo "::error::expected exactly 1 images entry named '${name}' in ${OVERLAY}/kustomization.yaml, found ${n}"
+              exit 1
+            fi
+            NAME="$name" TAG="$tag" yq -i \
+              '(.images[] | select(.name == strenv(NAME))).newTag = strenv(TAG)' \
+              "${OVERLAY}/kustomization.yaml"
+          }
+          if [ -n "${BACKEND_TAG}" ]; then
+            # One repo, one build, one SHA - these two always move together.
+            set_tag dataquest/dspace       "${BACKEND_TAG}"
+            set_tag dataquest/dspace-solr  "${BACKEND_TAG}"
+          fi
+          if [ -n "${FRONTEND_TAG}" ]; then
+            set_tag dataquest/dspace-angular "${FRONTEND_TAG}"
+          fi
+
+          if git diff --quiet -- "${OVERLAY}/kustomization.yaml"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No tag change (already at the requested version)."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff -- "${OVERLAY}/kustomization.yaml"
+          fi
+
+      - name: Commit the pinned tags
+        if: ${{ steps.pin.outputs.changed == 'true' }}
+        env:
+          BACKEND_TAG: ${{ steps.resolve.outputs.backend_tag }}
+          FRONTEND_TAG: ${{ steps.resolve.outputs.frontend_tag }}
+          SOURCE_REPO: ${{ github.event.client_payload.component == 'frontend' && 'ufal/dspace-angular' || 'ufal/clarin-dspace' }}
+        run: |
+          set -euo pipefail
+          # Commit BEFORE anything reaches the cluster. This is the whole point
+          # of the pull model: git is the desired state, so the worst case is
+          # "git ahead of cluster", which the next reconcile closes by itself.
+          # The old push-based design committed only after a green rollout and
+          # so could leave the cluster ahead of git - a state the next deploy of
+          # the other component would silently roll back.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ -n "${BACKEND_TAG}" ]; then
+            MSG="ok-dspace: backend -> ${BACKEND_TAG:0:12}"
+          else
+            MSG="ok-dspace: frontend -> ${FRONTEND_TAG:0:12}"
+          fi
+          git add "${OVERLAY}/kustomization.yaml"
+          git commit -m "${MSG}" -m "Pinned by ${GITHUB_WORKFLOW} run ${GITHUB_RUN_ID} from ${SOURCE_REPO}."
+
+          # Retry against a concurrent push to main. The concurrency group makes
+          # this unlikely, but a lost push means the deploy silently never
+          # happens - there is no other channel to the cluster.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "Pushed on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}); rebasing and retrying..."
+            # `|| git rebase --abort` is load-bearing. A conflicting rebase
+            # leaves HEAD detached at the new upstream tip, where the CI commit
+            # no longer exists - so the next `git push origin HEAD:main` reports
+            # "Everything up-to-date" and EXITS 0. The loop would then announce
+            # a successful push having pushed nothing, which is precisely the
+            # silent-non-deploy this retry exists to prevent. Aborting puts HEAD
+            # back on the CI commit so the next attempt fails honestly.
+            git pull --rebase origin main || git rebase --abort || true
+          done
+          echo "::error::Could not push the pinned tag, so the deploy will not happen."
+          exit 1
+
+      - name: Summary
+        if: always()
+        env:
+          BACKEND_TAG: ${{ steps.resolve.outputs.backend_tag }}
+          FRONTEND_TAG: ${{ steps.resolve.outputs.frontend_tag }}
+          CHANGED: ${{ steps.pin.outputs.changed }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ok-dspace pin"
+            echo
+            echo "- Trigger: \`${GITHUB_EVENT_NAME}\`"
+            [ -n "${BACKEND_TAG}" ]  && echo "- Backend: \`${BACKEND_TAG}\` (ufal/clarin-dspace)"  || true
+            [ -n "${FRONTEND_TAG}" ] && echo "- Frontend: \`${FRONTEND_TAG}\` (ufal/dspace-angular)" || true
+            echo "- Tag changed: \`${CHANGED:-unknown}\`"
+            echo "- URL: ${PUBLIC_URL}"
+            echo
+            echo "The in-cluster reconciler applies this within ~5 minutes."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Confirms the environment really ends up serving what was just pinned. This
+  # is the only signal that the deploy worked: nothing in the pin job can see
+  # the cluster, by design.
+  verify:
+    needs: pin
+    uses: ./.github/workflows/verify-ok-dspace.yml
+    with:
+      backend_sha: ${{ needs.pin.outputs.backend_sha }}
+      frontend_sha: ${{ needs.pin.outputs.frontend_sha }}
+      # Must cover the reconcile interval (up to 5m) plus a full backend
+      # restart, for which the reconciler itself allows 20m - it re-runs
+      # `database migrate` and `index-discovery -b`. 35 leaves margin over that
+      # ~25m worst case rather than racing it.
+      timeout_minutes: 35

--- a/.github/workflows/pin-ok-dspace.yml
+++ b/.github/workflows/pin-ok-dspace.yml
@@ -49,6 +49,10 @@ env:
   OVERLAY: overlays/kosarko-ns
   PUBLIC_URL: https://ok-dspace.dyn.cloud.e-infra.cz
   YQ_VERSION: v4.53.3
+  # SHA-256 of yq_linux_amd64 for YQ_VERSION, from that release's own
+  # `checksums` asset. Update BOTH together - a version bump with a stale
+  # checksum fails the install step, which is the intended behaviour.
+  YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
 
 jobs:
   pin:
@@ -81,6 +85,11 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/bin"
           curl -fsSL -o "${RUNNER_TEMP}/bin/yq" \
             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          # This job holds contents:write on the repository, so an unverified
+          # binary fetched over the network would be arbitrary code execution
+          # with permission to commit to main. Pinning the version alone does
+          # not help: release assets can be replaced.
+          echo "${YQ_SHA256}  ${RUNNER_TEMP}/bin/yq" | sha256sum -c -
           chmod +x "${RUNNER_TEMP}/bin/yq"
           echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
 
@@ -100,6 +109,15 @@ jobs:
           FRONTEND_TAG=""
 
           if [ "${EVENT_NAME}" = "repository_dispatch" ]; then
+            # This path exists to carry the commit that produced the image, and
+            # the app repos always send `github.sha`. Requiring a full sha here
+            # - rather than accepting any tag, as a manual pin may - keeps an
+            # accidental or hostile dispatch from pinning some other existing
+            # tag, and guarantees `verify` always has something to assert.
+            if ! printf '%s' "${PAYLOAD_SHA}" | grep -qE '^[0-9a-fA-F]{40}$'; then
+              echo "::error::client_payload.sha must be a full 40-character commit sha, got: '${PAYLOAD_SHA}'"
+              exit 1
+            fi
             case "${PAYLOAD_COMPONENT}" in
               backend)  BACKEND_TAG="${PAYLOAD_SHA}" ;;
               frontend) FRONTEND_TAG="${PAYLOAD_SHA}" ;;

--- a/.github/workflows/pin-ok-dspace.yml
+++ b/.github/workflows/pin-ok-dspace.yml
@@ -121,20 +121,16 @@ jobs:
             fi
           done
 
-          # A tag is not necessarily a commit sha: `workflow_dispatch` accepts
-          # any image tag, and main currently pins a branch-name tag. Only a
-          # sha can be checked against what the deployed app reports, so emit
-          # these separately - verify gates on the sha outputs and falls back
-          # to a reachability-only check when they are empty. Passing a
-          # branch-name tag through would fail verify's sha validation and turn
-          # a perfectly good deploy red.
-          # Full 40 hex only, NOT verify's {7,40}. An all-hex short tag - a date
-          # like `20260722` is the realistic one - would otherwise classify as a
-          # sha, and verify would then poll 35 minutes for a commit that does
-          # not exist and fail a perfectly good deploy. `github.sha` is always
-          # 40 chars and a human pinning a sha pastes the whole thing, so
-          # nothing legitimate is lost here. Verify keeps {7,40} because a short
-          # sha is a reasonable thing to type into ITS dispatch form.
+          # A tag is not necessarily a commit sha - workflow_dispatch accepts
+          # any image tag - and only a sha can be checked against what the
+          # deployed application reports. Emit them separately so verify gates
+          # on the sha outputs and falls back to a reachability-only check when
+          # they are empty, instead of failing a good deploy.
+          #
+          # Full 40 hex here, NOT verify's {7,40}: an all-hex short tag such as
+          # a date (`20260722`) would otherwise be treated as a sha that does
+          # not exist. `github.sha` is always 40 characters, so nothing
+          # legitimate is lost.
           sha_or_empty() {
             printf '%s' "$1" | grep -qE '^[0-9a-fA-F]{40}$' && printf '%s' "$1" || true
           }
@@ -240,7 +236,7 @@ jobs:
         env:
           BACKEND_TAG: ${{ steps.resolve.outputs.backend_tag }}
           FRONTEND_TAG: ${{ steps.resolve.outputs.frontend_tag }}
-          SOURCE_REPO: ${{ github.event.client_payload.component == 'frontend' && 'ufal/dspace-angular' || 'ufal/clarin-dspace' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           # Commit BEFORE anything reaches the cluster. This is the whole point
@@ -252,13 +248,29 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if [ -n "${BACKEND_TAG}" ]; then
-            MSG="ok-dspace: backend -> ${BACKEND_TAG:0:12}"
+          # Both tags can be set at once by a manual dispatch, so build the
+          # subject from whatever actually changed rather than assuming one.
+          WHAT=""
+          [ -n "${BACKEND_TAG}" ]  && WHAT="backend -> ${BACKEND_TAG:0:12}"
+          [ -n "${FRONTEND_TAG}" ] && WHAT="${WHAT:+${WHAT}, }frontend -> ${FRONTEND_TAG:0:12}"
+          MSG="ok-dspace: ${WHAT}"
+
+          # Attribute the pin to what actually triggered it. Deriving this from
+          # client_payload alone would credit ufal/clarin-dspace for every
+          # manual run, including frontend-only ones, because the payload is
+          # empty on workflow_dispatch.
+          if [ "${EVENT_NAME}" = "repository_dispatch" ]; then
+            if [ -n "${BACKEND_TAG}" ]; then
+              TRIGGER="a dispatch from ufal/clarin-dspace"
+            else
+              TRIGGER="a dispatch from ufal/dspace-angular"
+            fi
           else
-            MSG="ok-dspace: frontend -> ${FRONTEND_TAG:0:12}"
+            TRIGGER="a manual ${EVENT_NAME}"
           fi
+
           git add "${OVERLAY}/kustomization.yaml"
-          git commit -m "${MSG}" -m "Pinned by ${GITHUB_WORKFLOW} run ${GITHUB_RUN_ID} from ${SOURCE_REPO}."
+          git commit -m "${MSG}" -m "Pinned by ${GITHUB_WORKFLOW} run ${GITHUB_RUN_ID}, from ${TRIGGER}."
 
           # Retry against a concurrent push to main. The concurrency group makes
           # this unlikely, but a lost push means the deploy silently never

--- a/.github/workflows/verify-ok-dspace.yml
+++ b/.github/workflows/verify-ok-dspace.yml
@@ -97,7 +97,7 @@ jobs:
           # changes - so matching the first 40-hex on the page would report a
           # stale frontend as up to date. Never relax this to a bare hex match.
           extract_sha() {
-            grep -oE 'Git hash:.{0,120}' | head -1 | grep -oE '[0-9a-f]{40}' | head -1 || true
+            grep -oE 'Git hash:.{0,120}' | head -1 | grep -oiE '[0-9a-f]{40}' | head -1 || true
           }
 
           probe_backend() {

--- a/.github/workflows/verify-ok-dspace.yml
+++ b/.github/workflows/verify-ok-dspace.yml
@@ -1,0 +1,198 @@
+# Verifies ok-dspace from OUTSIDE the cluster, over the real public URL.
+#
+# This is deliberately a GitHub-hosted job, not an in-cluster one. Reaching
+# https://ok-dspace.dyn.cloud.e-infra.cz from a pod inside kosarko-ns needs
+# hairpin NAT back through the external ingress, which plenty of CNI/LB setups
+# do not support - so the deploy workflow's own public-URL check has to be
+# non-fatal to avoid failing every deploy. Run from GitHub, the same request
+# takes the path a real user takes (DNS -> LB -> ingress -> TLS -> app), so it
+# can be fatal and actually mean something.
+#
+# Both components publish the commit they were built from, so this asserts the
+# intended code is really being served - not merely that something answers:
+#
+#   backend   GET /server/api            -> .buildVersion  ("Git hash: <sha> ...")
+#   frontend  GET /static/VERSION_D      -> SSR'd HTML     ("Git hash: <sha> ...")
+#
+# Both are produced at image build time by scripts/sourceversion.py in the
+# respective source repo, so the sha is the source commit - the same value the
+# deploy pins as the image tag.
+#
+# Architecture-independent on purpose: it needs only the public URL and the shas
+# that were supposed to be deployed. It works whether the apply came from the
+# in-cluster Actions runner or from a pull-based reconciler, so it survives a
+# change of deploy mechanism unchanged.
+name: Verify ok-dspace
+
+on:
+  workflow_call:
+    inputs:
+      backend_sha:
+        description: "clarin-dspace commit expected to be serving (blank = skip)"
+        required: false
+        type: string
+      frontend_sha:
+        description: "dspace-angular commit expected to be serving (blank = skip)"
+        required: false
+        type: string
+      timeout_minutes:
+        description: "How long to keep polling for the expected shas"
+        required: false
+        default: 30
+        type: number
+  workflow_dispatch:
+    inputs:
+      backend_sha:
+        description: "clarin-dspace commit expected to be serving (blank = skip)"
+        required: false
+        type: string
+      frontend_sha:
+        description: "dspace-angular commit expected to be serving (blank = skip)"
+        required: false
+        type: string
+      timeout_minutes:
+        description: "How long to keep polling for the expected shas"
+        required: false
+        default: 30
+        type: number
+
+# Reads nothing, writes nothing. This job holds no credential of any kind: the
+# endpoints it hits are public.
+permissions: {}
+
+env:
+  PUBLIC_URL: https://ok-dspace.dyn.cloud.e-infra.cz
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    # Bounded above the poll window so a hung curl cannot pin a runner.
+    timeout-minutes: 45
+
+    steps:
+      - name: Wait for the expected commits to be served
+        id: probe
+        env:
+          # External input by way of client_payload; never interpolated into the
+          # script body. Same pattern as pin-ok-dspace.yml.
+          EXPECTED_BACKEND: ${{ inputs.backend_sha }}
+          EXPECTED_FRONTEND: ${{ inputs.frontend_sha }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+        run: |
+          set -euo pipefail
+
+          for s in "${EXPECTED_BACKEND}" "${EXPECTED_FRONTEND}"; do
+            if [ -n "$s" ] && ! printf '%s' "$s" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+              echo "::error::refusing malformed commit sha: '$s'"
+              exit 1
+            fi
+          done
+
+          # Pull the sha out of a "Git hash: ... <40 hex>" blob.
+          #
+          # ANCHORED ON PURPOSE. The frontend page also carries
+          # data-build="<40 hex>" on the lindat-common header and footer, and it
+          # appears EARLIER in the document. That attribute is the shared
+          # component library's hash - it does not move when dspace-angular
+          # changes - so matching the first 40-hex on the page would report a
+          # stale frontend as up to date. Never relax this to a bare hex match.
+          extract_sha() {
+            grep -oE 'Git hash:.{0,120}' | head -1 | grep -oE '[0-9a-f]{40}' | head -1 || true
+          }
+
+          probe_backend() {
+            curl -fsS --max-time 30 "${PUBLIC_URL}/server/api" \
+              | jq -r '.buildVersion // empty' | extract_sha
+          }
+
+          probe_frontend() {
+            # Server-side rendered, so the sha is in the HTML curl receives.
+            curl -fsS --max-time 30 "${PUBLIC_URL}/static/VERSION_D" | extract_sha
+          }
+
+          # Poll rather than sleep for a fixed interval: succeed as soon as the
+          # new build is live, and spend the full window only on a real failure.
+          # The backend re-runs `database migrate` plus a full `index-discovery
+          # -b` on every start, so the slow case is minutes, not seconds.
+          deadline=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+          attempt=0
+          backend_live=""
+          frontend_live=""
+
+          while :; do
+            attempt=$((attempt + 1))
+            ok=true
+
+            backend_live="$(probe_backend || true)"
+            frontend_live="$(probe_frontend || true)"
+
+            # An empty expectation means "this component was not part of this
+            # deploy" - still report what it serves, but do not gate on it.
+            if [ -n "${EXPECTED_BACKEND}" ] && \
+               ! printf '%s' "${backend_live}" | grep -qiE "^${EXPECTED_BACKEND}"; then
+              ok=false
+            fi
+            if [ -n "${EXPECTED_FRONTEND}" ] && \
+               ! printf '%s' "${frontend_live}" | grep -qiE "^${EXPECTED_FRONTEND}"; then
+              ok=false
+            fi
+            # With nothing to assert, require only that both endpoints answer
+            # with a parseable build - which still proves DNS, ingress and TLS.
+            if [ -z "${EXPECTED_BACKEND}${EXPECTED_FRONTEND}" ] && \
+               { [ -z "${backend_live}" ] || [ -z "${frontend_live}" ]; }; then
+              ok=false
+            fi
+
+            if [ "${ok}" = true ]; then
+              echo "Verified after ${attempt} attempt(s)."
+              break
+            fi
+
+            echo "attempt ${attempt}: backend=${backend_live:-<none>} frontend=${frontend_live:-<none>}"
+
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "::error::${PUBLIC_URL} did not serve the expected commits within ${TIMEOUT_MINUTES}m."
+              echo "::error::  backend  expected=${EXPECTED_BACKEND:-<any>} live=${backend_live:-<unreachable>}"
+              echo "::error::  frontend expected=${EXPECTED_FRONTEND:-<any>} live=${frontend_live:-<unreachable>}"
+              echo "::error::The rollout may have failed, or the reconcile never ran. Check:"
+              echo "::error::  kubectl get deploy -n kosarko-ns -o jsonpath='{..image}'"
+              exit 1
+            fi
+            sleep 30
+          done
+
+          {
+            echo "backend_live=${backend_live}"
+            echo "frontend_live=${frontend_live}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        if: always()
+        env:
+          EXPECTED_BACKEND: ${{ inputs.backend_sha }}
+          EXPECTED_FRONTEND: ${{ inputs.frontend_sha }}
+          BACKEND_LIVE: ${{ steps.probe.outputs.backend_live }}
+          FRONTEND_LIVE: ${{ steps.probe.outputs.frontend_live }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## ok-dspace verification"
+            echo
+            echo "Checked from GitHub over the public URL: ${PUBLIC_URL}"
+            echo
+            echo "| Component | Expected | Serving |"
+            echo "|---|---|---|"
+            echo "| backend (clarin-dspace) | \`${EXPECTED_BACKEND:-(any)}\` | \`${BACKEND_LIVE:-unreachable}\` |"
+            echo "| frontend (dspace-angular) | \`${EXPECTED_FRONTEND:-(any)}\` | \`${FRONTEND_LIVE:-unreachable}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+# ---------------------------------------------------------------------------
+# WHERE THE TEST SUITE HOOKS IN
+#
+# This job is the seam: it is the first point at which "the intended commit is
+# really being served over the public URL" is known to be true, which is exactly
+# the precondition an e2e suite needs. Add the tests as a job that `needs:` this
+# one (or dispatch them from here), passing the probe outputs through so a test
+# report records which commits it actually tested. Deliberately not wired up
+# yet - tests are a separate piece of work.
+# ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Resource limits and requests have been calibrated based on production metrics (d
 The repository ships with a small helper script **`init_overlay.sh`** that automates the creation of a Kustomize overlay from a set of `*.yaml.template` files located in `overlays/template`.
 It also ships with a sample overlay setup (inited by the script) in `overlays/kosarko-ns`.
 
+> **Note:** `overlays/kosarko-ns` is no longer just a sample — it is the **ok-dspace test environment**, deployed automatically by CI. See [Continuous deployment](#continuous-deployment-ok-dspace) below. Its `images[].newTag` values are maintained by the pin workflow, and the whole overlay is re-applied to the cluster every five minutes by an in-cluster reconciler — so hand-edits to either the file or the running objects are reverted. If you want a fresh sample overlay to copy, run `init_overlay.sh` with a new name.
+
 #### Using the newly‑created overlay
 
 Once the overlay exists you can apply the whole stack with a single `kubectl apply -k` command, pointing at the overlay directory:
@@ -174,6 +176,55 @@ If you need to change **only** the namespace, hostname, or TLS secret name you c
 If you modify the original template files, delete the existing overlay directory (or rename it) and run the script again to regenerate fresh manifests.
 
 *The `init_overlay.sh` script is intentionally lightweight and has **no external dependencies** beyond Bash, `envsubst` (part of the GNU `gettext` package), and standard Unix utilities. It is safe to run on any POSIX‑compatible shell.*
+
+## Continuous deployment (ok-dspace)
+
+`overlays/kosarko-ns` — <https://ok-dspace.dyn.cloud.e-infra.cz>, namespace `kosarko-ns` — redeploys
+automatically. Other overlays are unaffected and remain manual.
+
+**Triggers**
+
+| Trigger | Effect |
+|---|---|
+| Push to `clarin-v7` in `ufal/clarin-dspace` | after the images build, pins `ufal/dspace` + `ufal/dspace-solr` to that commit SHA |
+| Push to `clarin-v7` in `ufal/dspace-angular` | after the image builds, pins `ufal/dspace-angular` to that commit SHA |
+| Manual `workflow_dispatch` | pin explicit tags, or re-verify what is already committed |
+
+**It is pull-based.** Nothing pushes into the cluster. Three pieces:
+
+1. Each app repo's `docker.yml` ends with a `deploy-ok-dspace` job that sends a `repository_dispatch`
+   here — so **no cluster credential exists in the application repositories**.
+2. [`.github/workflows/pin-ok-dspace.yml`](.github/workflows/pin-ok-dspace.yml) resolves the tag,
+   checks it really exists on Docker Hub, and commits it to `main`. It runs on `ubuntu-latest` and
+   **never touches the cluster**.
+3. A CronJob inside `kosarko-ns` pulls `main` every five minutes and applies it — see
+   [`ci-reconcile/README.md`](ci-reconcile/README.md) for the bootstrap, the RBAC scoping, the
+   security posture, and how to pause or kick it.
+
+The result: **no cluster credential in GitHub, and no GitHub credential in the cluster.** The
+repository is public, so the reconciler needs no token to read it, and it applies with its own
+in-cluster ServiceAccount.
+
+**How versions are tracked.** The pin workflow rewrites only *its own* component's tag in
+`overlays/kosarko-ns/kustomization.yaml`, so a backend deploy can never reassert a stale frontend
+tag. Because the commit lands *before* the cluster changes, git is the desired state and the cluster
+converges to it. Both components report the commit they are actually running:
+
+```bash
+curl -s https://ok-dspace.dyn.cloud.e-infra.cz/server/api | jq -r .buildVersion
+curl -s https://ok-dspace.dyn.cloud.e-infra.cz/static/VERSION_D | grep -o 'Git hash:.*'
+```
+
+[`verify-ok-dspace.yml`](.github/workflows/verify-ok-dspace.yml) polls exactly those after every pin,
+from GitHub, over the public URL — so a green check means the public site really serves the new
+commit, through real DNS, ingress and TLS.
+
+**Hand edits do not survive.** The reconciler re-applies `main` every five minutes, so anything
+patched directly into the cluster is reverted. Suspend the CronJob first if you need it to persist
+(see `ci-reconcile/README.md`).
+
+**Deploys are non-destructive** — no database, Solr or S3 wipe. The backend's `database migrate
+force` init container keeps the schema tracking the code without one.
 
 ## Pre-Deployment Configuration (when not using overlays)
 

--- a/ci-reconcile/README.md
+++ b/ci-reconcile/README.md
@@ -1,0 +1,229 @@
+# ok-dspace reconciler
+
+A CronJob inside the `kosarko-ns` namespace that pulls `ufal/dspace-k8s` `main` every five minutes
+and applies `overlays/kosarko-ns` to the ok-dspace test environment
+(`https://ok-dspace.dyn.cloud.e-infra.cz`).
+
+It is one half of a deliberate split:
+
+| Where | What | Credentials it holds |
+|---|---|---|
+| GitHub, `ubuntu-latest` | [`pin-ok-dspace.yml`](../.github/workflows/pin-ok-dspace.yml) resolves an image tag, checks it exists on Docker Hub, writes it to `main` | `GITHUB_TOKEN` only |
+| Cluster, this CronJob | notices the commit and applies it | its own ServiceAccount token |
+| GitHub, `ubuntu-latest` | [`verify-ok-dspace.yml`](../.github/workflows/verify-ok-dspace.yml) polls the public URL until the new commit is served | none |
+
+**No cluster credential exists in GitHub, and no GitHub credential exists in the cluster.** The
+repository is public, so the reconciler fetches it anonymously; the apply uses the pod's projected
+`dspace-deployer` token, which the kubelet rotates.
+
+## Why pull rather than push
+
+The obvious alternative — a CI job that runs `kubectl apply` — needs a cluster credential wherever it
+runs. Putting it on a GitHub-hosted runner means storing a Rancher token as a repository secret: it
+expires, and it is a standing credential in a system you do not control. Putting it on a
+**self-hosted runner in this namespace** avoids that, but a self-hosted runner attached to a *public*
+repository is a known footgun — it executes whatever the workflow says on hardware holding namespace
+credentials, and it needs a GitHub PAT with `Administration: write` in-cluster just to register
+itself. This environment was built that way first and then replaced; see HANDOFF for the full
+reasoning.
+
+Pulling removes the whole class of problem. Nothing outside the cluster can execute code inside it;
+the only inputs are the contents of `main` and the pinned reconciler image.
+
+Two further consequences worth knowing:
+
+- **Drift is self-correcting.** A hand-patched Deployment is reverted within one interval. The
+  push-based design only applied on dispatch, so hand edits survived indefinitely.
+- **The dangerous failure ordering is gone.** Tags are committed *before* anything reaches the
+  cluster, so the worst case is "git ahead of cluster", which the next tick closes by itself. The
+  push-based design committed only after a green rollout, so a failed push left the *cluster* ahead
+  of git — the state that lets the next deploy of the other component silently roll it back.
+
+## What gets created
+
+| Resource | Name | Purpose |
+|---|---|---|
+| ServiceAccount | `dspace-deployer` | identity the reconciler uses against the API server |
+| Role | `dspace-deployer` | tightly scoped deploy permissions (see below) |
+| RoleBinding | `dspace-deployer` | binds the two |
+| CronJob | `ok-dspace-reconcile` | fetch `main`, `kubectl apply -k`, wait for rollout |
+
+## Bootstrap
+
+Prerequisites were confirmed for `kosarko-ns` and only need re-checking somewhere new: `create` on
+serviceaccounts/roles/rolebindings, quota headroom, no NetworkPolicy, egress to GitHub.
+
+```bash
+# Guard: this MUST print https://rancher.cloud.e-infra.cz/...
+kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'
+
+kubectl apply -k ci-reconcile/
+
+# Run it once immediately rather than waiting for the next tick.
+kubectl create job -n kosarko-ns --from=cronjob/ok-dspace-reconcile ok-dspace-reconcile-bootstrap
+kubectl logs -n kosarko-ns -l app=ok-dspace-reconcile --tail=50 -f
+```
+
+Then confirm the permission boundary is what it claims:
+
+```bash
+kubectl auth can-i --as=system:serviceaccount:kosarko-ns:dspace-deployer \
+  -n kosarko-ns patch deployments     # yes
+kubectl auth can-i --as=system:serviceaccount:kosarko-ns:dspace-deployer \
+  -n kosarko-ns create deployments    # no
+kubectl auth can-i --as=system:serviceaccount:kosarko-ns:dspace-deployer \
+  -n kosarko-ns delete deployments    # no
+kubectl auth can-i --as=system:serviceaccount:kosarko-ns:dspace-deployer \
+  -n kosarko-ns get secrets           # no
+```
+
+There is **no secret to create and no PAT to mint** — that is the point.
+
+### Keeping the Role in step with the overlay
+
+The Role is scoped to the *kinds the overlay actually contains*, so **adding a new kind to
+`overlays/kosarko-ns` breaks the reconcile on every tick until the Role is extended.** The failure is
+quiet from GitHub's side: the job fails, nothing is applied, and `verify` simply times out. Check
+coverage after changing the overlay:
+
+```bash
+kubectl kustomize overlays/kosarko-ns | grep -E '^(apiVersion|kind):'
+```
+
+Every (apiGroup, kind) pair must have a matching rule in `role.yaml`. Verified for the current
+overlay — ConfigMap, PersistentVolumeClaim, Service, Deployment, StatefulSet, CronJob, Ingress, CNPG
+Cluster + ScheduledBackup, barman-cloud ObjectStore, SealedSecret — all covered, with no
+cluster-scoped objects (a namespaced Role could never authorize a `Namespace`) and no raw `Secret`.
+
+## Permissions
+
+`role.yaml` grants exactly what `kubectl apply -k overlays/kosarko-ns` plus `kubectl rollout status`
+need, and nothing else.
+
+### What RBAC here cannot do
+
+The reconciler needs `patch`/`update` on Deployments and StatefulSets — that is how an image tag
+change is applied — and **patching a workload rewrites its pod template.** So anything holding this
+token can run an arbitrary image, and mount any Secret in the namespace into it, by patching an
+existing Deployment. It never needs `create`. PodSecurity `restricted` does not help either: a
+compliant pod still mounts Secrets and still runs any non-root image.
+
+**RBAC therefore cannot bound whatever holds this token.** What makes that acceptable here is that
+nothing arbitrary runs in this pod — the only inputs are `main` and the pinned image. Protect those
+two and the Role never has to be the last line of defence. Bounding it properly would take a
+ValidatingAdmissionPolicy restricting this ServiceAccount's Deployment patches to the image field.
+
+### What it does buy
+
+- **No `delete` on anything.** The deploy path cannot destroy the environment or its PVCs. This holds
+  even against a compromised reconciler. A reset/wipe capability is a conscious, separate grant.
+- **No `resourcequotas`, `roles` or `rolebindings`.** Blast radius stays pinned inside `kosarko-ns`.
+- **No `create` on pod-spawning controllers** — least-privilege hygiene, since steady-state apply
+  does not need it. **Not** a barrier to arbitrary workloads; see above.
+- **No `secrets` access.** Stops API reads; does not stop a mount.
+
+*Known costs:* with no `delete`, the hashed ConfigMaps from `configMapGenerator` accumulate — prune
+occasionally. With no `create` on workloads, a **brand-new** Deployment/StatefulSet/CronJob/Cluster
+in the overlay makes the reconcile fail; apply that one by hand once, and it is maintained from then
+on.
+
+## Operating it
+
+**Deploy now instead of waiting for the tick:**
+
+```bash
+kubectl create job -n kosarko-ns --from=cronjob/ok-dspace-reconcile \
+  ok-dspace-reconcile-$(date +%s)
+```
+
+**Pause reconciliation** — required if you want hand edits to survive, e.g. while debugging.
+Otherwise they are reverted within five minutes:
+
+```bash
+kubectl patch cronjob/ok-dspace-reconcile -n kosarko-ns -p '{"spec":{"suspend":true}}'
+# ... and afterwards, do not forget:
+kubectl patch cronjob/ok-dspace-reconcile -n kosarko-ns -p '{"spec":{"suspend":false}}'
+```
+
+**Force a restart at the same version.** `apply` is a no-op when nothing changed, so re-pinning an
+identical tag restarts nothing:
+
+```bash
+kubectl rollout restart deployment/dspace-backend -n kosarko-ns
+```
+
+**See what it did:**
+
+```bash
+kubectl get jobs -n kosarko-ns -l app=ok-dspace-reconcile
+kubectl logs -n kosarko-ns -l app=ok-dspace-reconcile --tail=50
+```
+
+**Deploy by hand** (the reconciler is not required for this):
+
+```bash
+kubectl apply -k overlays/kosarko-ns
+kubectl rollout status deployment/dspace-backend -n kosarko-ns --timeout=20m
+```
+
+A manual apply does not update the pinned tags in `overlays/kosarko-ns/kustomization.yaml` — and the
+next tick reverts anything that contradicts `main`.
+
+## Reading the logs: `configured` does not mean something changed
+
+Every reconcile reports `configured` for the two Deployments, the StatefulSet, the nine app CronJobs
+and the CNPG Cluster — thirteen objects — even when nothing has changed. **This is cosmetic. Do not
+go looking for drift.**
+
+Kubernetes resource quantities are strings, but the manifests in `k8s/` write `cpu: 1` as a YAML
+*integer*. That lands in `last-applied-configuration` as `1` while the API server stores the
+canonical `"1"`, so `kubectl apply`'s three-way merge computes a non-empty patch every time. The
+server parses both to the same Quantity, treats it as a no-op, and does not even bump
+`resourceVersion`. Only the thirteen objects carrying a pod template are affected; Services, PVCs,
+Ingress, SealedSecrets and the ObjectStore all report `unchanged`.
+
+The tell that it is harmless: `kubectl diff -k overlays/kosarko-ns` reports **no differences** at the
+same moment, and `metadata.generation` does not move. If you ever need to confirm that on a live
+object:
+
+```bash
+kubectl get deploy/dspace-backend -n kosarko-ns -o jsonpath='{.metadata.generation}{"\n"}'
+```
+
+Stable generation across ticks means no spec is being rewritten. The fix, if the log noise ever
+matters enough — it costs you the ability to tell a real deploy from a no-op tick by reading the
+logs — is to quote the quantities in `k8s/` (`cpu: "1"`). That is a change to the base manifests,
+not to this directory.
+
+## Failure modes
+
+**A tag that does not exist does not take the site down.** The reconciler applies it, the new pods
+sit in `ImagePullBackOff`, and RollingUpdate keeps the old ReplicaSet serving — so the damage is "no
+new version", not "broken environment". `rollout status` fails, the reconcile job fails, and
+`verify` goes red. The pin workflow's Docker Hub check catches most of these ~30 minutes earlier,
+but it is a convenience, not the guarantee.
+
+**A manifest the Role cannot apply** fails the whole `kubectl apply -k`, every tick, so *nothing*
+in the overlay updates — not just the offending object. See "Keeping the Role in step with the
+overlay" above.
+
+### Known gap: failures between pins are invisible
+
+`verify-ok-dspace.yml` catches a broken deploy, but it only runs when something is *pinned*. If the
+reconciler starts failing on its own — the tarball fetch breaks, `main` acquires a manifest the Role
+cannot apply, the image tag falls out of kubectl's supported skew — **nothing announces it.** The
+environment simply stops tracking `main`, and the next pin is the first thing to notice, up to 35
+minutes later.
+
+`failedJobsHistoryLimit: 3` keeps the evidence, but it is a place to look, not a signal. Until
+something watches it, `kubectl get jobs -n kosarko-ns -l app=ok-dspace-reconcile` is the manual
+check. This is the one thing a real GitOps controller (Flux, Argo) would give you for free, and the
+reason to revisit that choice if this environment ever matters more than it does today.
+
+## Maintenance
+
+**Bump `alpine/k8s`** in `cronjob.yaml` periodically. kubectl must stay within one minor of the API
+server: patch bumps are safe, a minor bump wants the cluster version checked first
+(`kubectl version`).
+
+**There is no credential to rotate.**

--- a/ci-reconcile/cronjob.yaml
+++ b/ci-reconcile/cronjob.yaml
@@ -1,0 +1,148 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ok-dspace-reconcile
+  labels:
+    app: ok-dspace-reconcile
+# Pulls the current state of ufal/dspace-k8s `main` and applies it to this
+# namespace. Nothing pushes into the cluster: this reconciler is the only thing
+# that applies, and it reaches out over plain HTTPS.
+#
+# Consequences worth understanding before changing anything here:
+#
+#   * NO CREDENTIAL OF ANY KIND. The repository is public, so the fetch is
+#     anonymous, and the apply uses this pod's own projected ServiceAccount
+#     token. There is no GitHub token in the cluster and no kubeconfig in
+#     GitHub. Keep it that way: if this ever needs a private repo, use a
+#     read-only deploy key in a SealedSecret, never a PAT.
+#   * `main` IS THE DESIRED STATE. Anything applied by hand is reverted within
+#     one interval. That is the point - it makes drift self-correcting - but it
+#     will undo your debugging. To pause:
+#         kubectl patch cronjob/ok-dspace-reconcile -n kosarko-ns \
+#           -p '{"spec":{"suspend":true}}'
+#     and remember to unsuspend.
+#   * A BROKEN main IS DEPLOYED FAITHFULLY. The guard against that is the pin
+#     workflow (which verifies image tags exist before committing) plus review
+#     of anything else landing on main - not this job.
+spec:
+  # Deploy latency is up to one interval on top of the image build. Five
+  # minutes is a deliberate compromise for a test environment; for an immediate
+  # deploy, kick it by hand:
+  #   kubectl create job -n kosarko-ns --from=cronjob/ok-dspace-reconcile \
+  #     ok-dspace-reconcile-manual-$(date +%s)
+  schedule: "*/5 * * * *"
+  # A reconcile can take 20+ minutes when the backend actually restarts, which
+  # is far longer than the interval. Overlapping applies of the same manifests
+  # would fight each other, so skip the tick instead.
+  concurrencyPolicy: Forbid
+  # If the controller was down, do not stampede through every missed tick.
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # No retries: the next tick is the retry, five minutes away, and a
+      # retry loop against a genuinely broken manifest just adds noise.
+      backoffLimit: 0
+      # Must EXCEED the rollout waits below, which are sequential and total
+      # 40m (20 + 10 + 10), plus the fetch. 45m leaves margin; anything under
+      # 40m would kill a legitimately slow reconcile mid-wait and report it as
+      # a failure. Keep this in step if those timeouts change.
+      activeDeadlineSeconds: 2700
+      template:
+        metadata:
+          labels:
+            app: ok-dspace-reconcile
+        spec:
+          serviceAccountName: dspace-deployer
+          restartPolicy: Never
+          # PodSecurity `restricted` is enforced cluster-wide on this cluster,
+          # and NOT advertised by namespace labels - do not conclude from
+          # absent labels that it is off. Every field below is required by it.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+            # The image runs read-only-ish as a non-root user; give the
+            # extracted tree somewhere writable that dies with the pod.
+            - name: workspace
+              emptyDir: {}
+          containers:
+            - name: reconcile
+              # kubectl + curl + tar in one small image. Pinned to the same
+              # minor the CI workflows use. kubectl must stay within one minor
+              # of the API server - confirm the cluster version before bumping
+              # across a minor (1.36+); patch bumps are safe.
+              image: docker.io/alpine/k8s:1.35.6
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              env:
+                # uid 1001 has no /etc/passwd entry in this image, so HOME
+                # would default to `/` (root-owned) and kubectl's discovery
+                # cache write would fail there. Point it at the writable
+                # emptyDir instead.
+                - name: HOME
+                  value: /workspace
+                - name: NAMESPACE
+                  value: kosarko-ns
+                - name: OVERLAY
+                  value: overlays/kosarko-ns
+                - name: TARBALL
+                  value: https://github.com/ufal/dspace-k8s/archive/refs/heads/main.tar.gz
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+              workingDir: /workspace
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+
+                  echo "Fetching ${TARBALL}"
+                  # Downloaded to a file and THEN extracted, deliberately not
+                  # piped: in `curl ... | tar ...` the exit status of curl is
+                  # discarded, so a truncated download would extract a partial
+                  # tree and be applied as if it were complete. Two steps make
+                  # both failures fatal without relying on `pipefail` being
+                  # available in the container's shell.
+                  curl -fsSL --retry 3 --retry-delay 5 -o repo.tar.gz "${TARBALL}"
+
+                  # --strip-components=1 drops the `dspace-k8s-main/` wrapper
+                  # GitHub adds, so paths match the repository layout - which
+                  # matters because the overlay bases on ../../k8s.
+                  mkdir -p src
+                  tar xzf repo.tar.gz --strip-components=1 -C src
+                  rm -f repo.tar.gz
+
+                  cd src
+
+                  echo "Applying ${OVERLAY}"
+                  # Every object in the overlay carries an explicit namespace,
+                  # so this does not depend on the pod's default namespace.
+                  # Apply is a no-op when nothing changed, which is the normal
+                  # case on most ticks.
+                  kubectl apply -k "${OVERLAY}"
+
+                  # Returns immediately when the workload is already at its
+                  # desired state, so this only actually waits after a change.
+                  # The backend re-runs `database migrate` plus a full
+                  # `index-discovery -b` on start, hence the generous timeout.
+                  kubectl rollout status deployment/dspace-backend -n "${NAMESPACE}" --timeout=20m
+                  kubectl rollout status deployment/dspace-angular -n "${NAMESPACE}" --timeout=10m
+                  kubectl rollout status statefulset/dspace-solr   -n "${NAMESPACE}" --timeout=10m
+
+                  echo "Reconciled."

--- a/ci-reconcile/cronjob.yaml
+++ b/ci-reconcile/cronjob.yaml
@@ -56,9 +56,16 @@ spec:
         spec:
           serviceAccountName: dspace-deployer
           restartPolicy: Never
-          # PodSecurity `restricted` is enforced cluster-wide on this cluster,
-          # and NOT advertised by namespace labels - do not conclude from
-          # absent labels that it is off. Every field below is required by it.
+          # PodSecurity `restricted` is enforced cluster-wide here and is NOT
+          # advertised by namespace labels - do not conclude from absent labels
+          # that it is off.
+          #
+          # The policy itself mandates only `runAsNonRoot: true`, the
+          # `seccompProfile`, `allowPrivilegeEscalation: false`,
+          # `capabilities.drop: ["ALL"]`, and an allowed volume type (emptyDir
+          # qualifies). The explicit uid/gid below are ours, so the pod runs as
+          # a known non-root user rather than whatever the image defaults to.
+          # No fsGroup is needed: an emptyDir is created world-writable.
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001

--- a/ci-reconcile/kustomization.yaml
+++ b/ci-reconcile/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# The reconciler that keeps ok-dspace in sync with `main`. Applied SEPARATELY
+# and MANUALLY — it is environment infrastructure, not part of the DSpace stack
+# in ../overlays/kosarko-ns, and it deliberately does not reconcile itself: a
+# broken change here would otherwise be unable to fix itself.
+#
+#   kubectl apply -k ci-reconcile/
+#
+# Needs no secret of any kind — the repository is public and the apply uses the
+# pod's own ServiceAccount token. See README.md.
+namespace: kosarko-ns
+
+resources:
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - cronjob.yaml

--- a/ci-reconcile/role.yaml
+++ b/ci-reconcile/role.yaml
@@ -1,0 +1,86 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dspace-deployer
+  labels:
+    app: ok-dspace-reconcile
+# Scoped to exactly what `kubectl apply -k overlays/kosarko-ns` plus
+# `kubectl rollout status` actually call. Deliberately NOT the built-in `edit`
+# ClusterRole.
+#
+# READ THIS FIRST: **RBAC cannot bound whatever holds this token.** Applying an
+# image tag requires `patch` on Deployments, and patching a workload rewrites
+# its pod template - so the absence of `create`, or of `secrets` access, stops
+# no determined caller. The full argument, and what the real boundary is, lives
+# in ci-reconcile/README.md under "Permissions". Do not re-derive it here.
+#
+# What this Role does buy is protection against *bugs*. The per-rule comments
+# below mark which granted verbs are load-bearing and which are hygiene - but an
+# absent verb has no rule to hang a comment on, so the two that matter most are
+# here:
+#   * no `delete` on anything -> the deploy path cannot destroy the environment
+#     or its PVCs, and this is the one guarantee that holds even against a
+#     compromised reconciler. Do NOT grant it to solve the ConfigMap
+#     accumulation noted below.
+#   * no `roles`/`rolebindings`/`resourcequotas` -> the blast radius cannot be
+#     widened from inside kosarko-ns.
+#
+# Known costs:
+#   * no `delete`: the hashed ConfigMaps produced by configMapGenerator
+#     accumulate over time. Prune them by hand occasionally.
+#   * no `create` on workloads: adding a *brand-new* Deployment/StatefulSet/
+#     CronJob/Cluster to the overlay makes the next reconcile fail. Apply that
+#     one by hand, once; CI then maintains it.
+#   * the rules must cover every kind the overlay renders - check with
+#     `kubectl kustomize overlays/kosarko-ns | grep -E '^(apiVersion|kind):'`
+#     after changing it, because a gap fails every tick with no other signal.
+rules:
+  # --- core -----------------------------------------------------------------
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # Read-only: `kubectl rollout status` and post-failure diagnostics.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["get", "list", "watch"]
+
+  # --- workloads ------------------------------------------------------------
+  # No `create` in this section: hygiene, not a boundary (steady-state apply
+  # does not need it). `patch`/`update` are unavoidable - that is how a tag
+  # change is applied.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # `kubectl rollout status deployment/...` walks the owned ReplicaSets.
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+  # --- CRDs the overlay ships ----------------------------------------------
+  # CloudNativePG Cluster: no `create`, like the workloads above - a Cluster
+  # runs Pods from a spec-supplied `imageName`.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # ScheduledBackup carries no image of its own; the operator runs backups
+  # through the existing instance pods, so `create` here spawns nothing new.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["scheduledbackups"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # barman-cloud plugin ObjectStore (S3 backup destination)
+  - apiGroups: ["barmancloud.cnpg.io"]
+    resources: ["objectstores"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # SealedSecrets: applying the encrypted form is safe — the ciphertext is
+  # bound to this name+namespace, so a new one cannot be forged here.
+  - apiGroups: ["bitnami.com"]
+    resources: ["sealedsecrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/ci-reconcile/rolebinding.yaml
+++ b/ci-reconcile/rolebinding.yaml
@@ -11,4 +11,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dspace-deployer
-    # namespace is injected by the kustomization
+    # Filled in by the kustomization's `namespace:` field. RBAC would also
+    # default an omitted ServiceAccount namespace to the RoleBinding's own, so
+    # this is explicitness rather than necessity.

--- a/ci-reconcile/rolebinding.yaml
+++ b/ci-reconcile/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dspace-deployer
+  labels:
+    app: ok-dspace-reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dspace-deployer
+subjects:
+  - kind: ServiceAccount
+    name: dspace-deployer
+    # namespace is injected by the kustomization

--- a/ci-reconcile/serviceaccount.yaml
+++ b/ci-reconcile/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dspace-deployer
+  labels:
+    app: ok-dspace-reconcile
+# The reconcile pod deploys to this namespace using THIS ServiceAccount's
+# projected token, which the kubelet rotates automatically. That is the whole
+# point of reconciling from inside the cluster: no kubeconfig, no Rancher API
+# token, and no expiring credential ever has to be stored as a GitHub secret.
+automountServiceAccountToken: true

--- a/overlays/kosarko-ns/kustomization.yaml
+++ b/overlays/kosarko-ns/kustomization.yaml
@@ -1,18 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../../k8s
-
-namespace: kosarko-ns   # <-- change to whatever you need
-
+namespace: kosarko-ns # <-- change to whatever you need
 configMapGenerator:
   - name: local-config-map
     behavior: merge
     files:
       - local.cfg
       - submission-forms.xml
-
 #images:
 #  - name: dataquest/dspace
 #    newName: ufal/dspace
@@ -51,7 +47,25 @@ patches:
       - op: replace
         path: /spec/rules/0/host
         value: "ok-dspace.dyn.cloud.e-infra.cz"
-
+# The newTag values below are MAINTAINED BY CI, by
+# .github/workflows/pin-ok-dspace.yml. They are pinned to the git SHA of the
+# source commit that produced the image, so this file records exactly what is
+# deployed. Hand-edits survive only until the next pin of that component.
+#
+# dspace + dspace-solr are built from the same ufal/clarin-dspace commit, so
+# they always move together. dspace-angular moves independently. An entry with
+# no newTag inherits the tag from ../../k8s until CI first pins it.
+#
+# THE `name:` VALUES ARE SELECTOR KEYS, NOT IMAGE NAMES. CI matches on
+# `dataquest/dspace` (the pre-rename name from ../../k8s) and rewrites newTag on
+# whatever it finds. Renaming these breaks the match; the workflow now fails
+# loudly if a key it expects is missing, but do not rename them casually.
+#
+# This file was reformatted once, deliberately, into yq's canonical output
+# (blank lines dropped, inline comment spacing normalised) so that every
+# CI-generated commit afterwards is a clean one-line tag change instead of the
+# first one silently reformatting everything. Verified byte-identical rendering
+# before and after. Do not "restore" the blank lines.
 images:
   - name: dataquest/dspace
     newName: ufal/dspace

--- a/overlays/kosarko-ns/kustomization.yaml
+++ b/overlays/kosarko-ns/kustomization.yaml
@@ -48,13 +48,16 @@ patches:
         path: /spec/rules/0/host
         value: "ok-dspace.dyn.cloud.e-infra.cz"
 # The newTag values below are MAINTAINED BY CI, by
-# .github/workflows/pin-ok-dspace.yml. They are pinned to the git SHA of the
-# source commit that produced the image, so this file records exactly what is
-# deployed. Hand-edits survive only until the next pin of that component.
+# .github/workflows/pin-ok-dspace.yml. An automated pin writes the git SHA of
+# the source commit that produced the image, so this file records which commit
+# is deployed - but the value is an image TAG, not necessarily a SHA: a manual
+# pin may set any tag, and an entry with no newTag at all inherits from
+# ../../k8s until CI first pins it. Read it as "the tag this environment runs",
+# and check the running version at /server/api and /static/VERSION_D if you
+# need certainty. Hand-edits survive only until the next pin of that component.
 #
 # dspace + dspace-solr are built from the same ufal/clarin-dspace commit, so
-# they always move together. dspace-angular moves independently. An entry with
-# no newTag inherits the tag from ../../k8s until CI first pins it.
+# they always move together. dspace-angular moves independently.
 #
 # THE `name:` VALUES ARE SELECTOR KEYS, NOT IMAGE NAMES. CI matches on
 # `dataquest/dspace` (the pre-rename name from ../../k8s) and rewrites newTag on


### PR DESCRIPTION
Makes <https://ok-dspace.dyn.cloud.e-infra.cz> (namespace `kosarko-ns`) redeploy automatically when
`ufal/clarin-dspace` or `ufal/dspace-angular` push to `clarin-v7`, and manually on demand. Other
overlays are untouched and stay manual.

### How it works

```
app repo push -> repository_dispatch -> pin-ok-dspace.yml (ubuntu-latest)
                                          validate tag, check Docker Hub, commit to main
                                     -> ci-reconcile CronJob (in kosarko-ns, every 5 min)
                                          fetch main, kubectl apply -k, wait for rollout
                                     -> verify-ok-dspace.yml (ubuntu-latest)
                                          poll the public URL for the new commit
```

**No cluster credential exists in GitHub, and no GitHub credential exists in the cluster.** The
repository is public, so the reconciler fetches it anonymously and applies with its own in-cluster
ServiceAccount. The only secret involved is `OK_DSPACE_DEPLOY_TOKEN`, which the *application* repos
use to send the dispatch — a workflow's own `GITHUB_TOKEN` cannot act cross-repo.

### Why pull rather than push

A CI job running `kubectl apply` needs a cluster credential wherever it runs: either a Rancher token
stored as a repository secret, which expires and lives in a system we do not control, or a
self-hosted runner in the namespace — which on a **public** repository executes workflow-defined
steps on hardware holding namespace credentials, and needs an `Administration: write` PAT in-cluster
just to register itself. Reconciling from inside removes that whole class of problem.

Two properties follow. Drift is self-correcting: a hand-patched object is reverted within one
interval. And the ordering failure becomes the safe one — git ahead of cluster closes itself on the
next tick, whereas committing only after a green rollout can leave the *cluster* ahead of git, which
is the state that lets the next deploy of the other component silently roll it back.

### Verified before this PR

The reconciler is already **running in `kosarko-ns`** and was proven before anything was pushed:

- First apply and a scheduled tick both completed; no workload restarted (pods stayed 12+ days old)
- `metadata.generation` stable across ticks for the Deployment, CronJob and CNPG Cluster — no churn
- RBAC boundary confirmed live: `patch deployments` yes; `create` / `delete deployments` and
  `get secrets` all no
- `kubectl kustomize overlays/kosarko-ns` renders **byte-identical to `main`** (3439 lines) — this
  branch asserts no image tags of its own
- The reconciler's real fetch path reproduces that same render; `actionlint` clean; shell syntax
  checked on all embedded scripts

### Review notes

Three subtleties are load-bearing and commented in place — please don't simplify them away:

- `set_tag` asserts exactly one matching `images:` entry. yq exits 0 writing nothing when its
  selector misses, which would otherwise report a green "no change" run that deployed nothing.
- `|| git rebase --abort` in the push retry. A conflicting rebase detaches HEAD at the upstream tip,
  after which `git push` says "Everything up-to-date" and **exits 0**.
- Verify anchors its sha match on `Git hash:`. `/static/VERSION_D` also contains
  `data-build="<40 hex>"` *earlier* in the page — that is lindat-common's hash and never moves, so a
  naive match would be a check that can never fail.

### Follow-ups, deliberately not here

- Quote the resource quantities in `k8s/` (`cpu: "1"`). Unquoted YAML integers make `kubectl apply`
  report `configured` for 13 objects on every reconcile even when nothing changed — cosmetic, and
  explained in `ci-reconcile/README.md`, but it costs the ability to read a real deploy out of the
  logs.
- `spec.monitoring.enablePodMonitor` is deprecated in the CNPG cluster manifest.

### Merge order

Merge this **first** — it defines the `deploy-ok-dspace` dispatch type the application repositories
send. Their PRs are inert until it lands.
