### PR TITLE
kosarko-ns: mark ok-dspace as a test instance (noindex + demo chrome)

### DIFF
--- a/overlays/kosarko-ns/angular-deployment.yaml
+++ b/overlays/kosarko-ns/angular-deployment.yaml
@@ -5,8 +5,36 @@ metadata:
 spec:
   template:
     spec:
+      # Drop the test-site stylesheet into the image's own assets/ directory.
+      # subPath mounts a single FILE, so this ADDS seed-testsite.css without
+      # shadowing the rest of assets/ (i18n, images, favicons) the way a
+      # directory mount would. The path must be under dist/browser/assets: the
+      # <link href> in config.yml is relative to the app base, and that directory
+      # is what expressStaticGzip serves.
+      #
+      # volumes and volumeMounts merge by `name`, so both blocks are additive --
+      # the inherited local-config volume and its mounts are untouched.
+      volumes:
+        - name: seed-testsite-css
+          configMap:
+            name: seed-testsite-css
+        - name: angular-config
+          configMap:
+            name: angular-config
       containers:
         - name: dspace-angular
           env:
             - name: DSPACE_REST_HOST
               value: "ok-dspace.dyn.cloud.e-infra.cz"
+          volumeMounts:
+            - name: seed-testsite-css
+              mountPath: /app/dist/browser/assets/seed-testsite.css
+              subPath: seed-testsite.css
+            # RE-POINT, not add. volumeMounts merge on `mountPath`, so declaring
+            # the same path with a different volume name REPLACES the inherited
+            # mount that read config.yml out of local-config. This is what keeps
+            # the frontend's config out of the backend's ConfigMap; see the long
+            # note in kustomization.yaml.
+            - name: angular-config
+              mountPath: /app/config/config.yml
+              subPath: config.yml

--- a/overlays/kosarko-ns/config.yml
+++ b/overlays/kosarko-ns/config.yml
@@ -1,0 +1,81 @@
+# Angular runtime config for ok-dspace.
+#
+# behavior: merge on a `files:` entry REPLACES the whole config.yml key in
+# local-config-map, so this must be a COMPLETE file, not just the delta. Lines 1-17
+# are k8s/config.yml verbatim -- deliberately including
+# rest.host = hello-clarin-dspace..., because overlays/kosarko-ns/angular-deployment.yaml
+# sets DSPACE_REST_HOST=ok-dspace.dyn.cloud.e-infra.cz and DSpace env vars override
+# config.yml. Changing the host here would be a behavioural change smuggled in with a
+# cosmetic one; keep this file a pure addition of the `themes:` block below.
+rest:
+  # For client-side (browser), use external HTTPS URL
+  ssl: true
+  host: hello-clarin-dspace.dyn.cloud.e-infra.cz
+  port: 443
+  nameSpace: /server
+ui:
+  # SSR server runs HTTP internally, ingress handles TLS
+  ssl: false
+  host: 0.0.0.0
+  port: 4000
+  nameSpace: /
+# Universal server-side settings
+universal:
+  preboot: true
+  async: true
+  time: false
+
+# ---------------------------------------------------------------------------
+# Test-site marking, config-only (no Angular image rebuild).
+#
+# ThemeService.createHeadTags() builds each entry with
+#   document.createElement(tagName) + setAttribute(k, v)
+# with NO allow-list on tagName or attributes, and it runs server-side, so these
+# land in the initial SSR HTML where crawlers look. Verified on the local k3s
+# stack: an anonymous curl of / returns the meta and link tags carrying
+# class="theme-head-tag".
+#
+# This is why noindex does NOT go through the ingress. On the local cluster
+# ingress-nginx v1.15.1 refuses `configuration-snippet` outright ("Snippet
+# directives are disabled by the Ingress administrator") and `custom-headers`
+# needs `global-allowed-response-headers` in the CLUSTER-scoped controller
+# ConfigMap, which a namespace tenant cannot set. Assume the same on e-infra
+# until shown otherwise. A robots meta tag is honoured by Google and Bing
+# identically to the header.
+#
+# NOTE: this list REPLACES DefaultAppConfig.themes, so the three favicon tags
+# that ship with the built-in `dspace` theme are repeated verbatim. Drop them and
+# ok-dspace loses its favicon, apple-touch-icon and web manifest.
+# ---------------------------------------------------------------------------
+themes:
+  - name: dspace
+    headTags:
+      # ok-dspace serves a synthetic corpus shaped like LINDAT. Keep it out of
+      # search results.
+      - tagName: meta
+        attributes:
+          name: robots
+          content: "noindex, nofollow"
+      # Test-site chrome. A separate small stylesheet on purpose: the built
+      # dspace-theme.css is ~344 KB and ships alongside .br/.gz siblings that
+      # express-static-gzip serves in preference to the .css, so patching it in
+      # place without regenerating those would silently serve stale CSS to every
+      # real browser.
+      - tagName: link
+        attributes:
+          rel: stylesheet
+          href: assets/seed-testsite.css
+      # --- unchanged defaults from DefaultAppConfig, repeated so they survive ---
+      - tagName: link
+        attributes:
+          rel: icon
+          href: assets/dspace/images/favicons/favicon.ico
+          sizes: any
+      - tagName: link
+        attributes:
+          rel: apple-touch-icon
+          href: assets/dspace/images/favicons/apple-touch-icon.png
+      - tagName: link
+        attributes:
+          rel: manifest
+          href: assets/dspace/images/favicons/manifest.webmanifest

--- a/overlays/kosarko-ns/kustomization.yaml
+++ b/overlays/kosarko-ns/kustomization.yaml
@@ -9,6 +9,33 @@ configMapGenerator:
     files:
       - local.cfg
       - submission-forms.xml
+  # ---------------------------------------------------------------------------
+  # The frontend's config.yml and stylesheet live in their OWN ConfigMaps, NOT as
+  # extra keys in local-config-map. That is deliberate and it is the whole reason
+  # this overlay is shaped this way:
+  #
+  # local-config-map is mounted by the BACKEND (local.cfg, user_exists.jsh) as
+  # well as the frontend. Adding a key to it changes its hash suffix, which
+  # changes the backend pod template, which restarts the backend -- init
+  # containers, `database migrate`, `index-discovery -b`, minutes of downtime,
+  # and an image re-pull on any floating tag. Doing exactly that on the local k3s
+  # stack on 2026-07-28 took the backend down for an hour. A purely cosmetic
+  # frontend change must not be able to bounce the backend, least of all from a
+  # reconciler tick nobody is watching.
+  #
+  # Split this way, editing config.yml or the CSS rolls ONLY dspace-angular.
+  #
+  # RBAC checked: ci-reconcile/role.yaml grants core/configmaps
+  # get,list,watch,create,update,patch, so the reconciler can create both. A
+  # missing verb would fail every 5-minute tick with no other signal.
+  # ---------------------------------------------------------------------------
+  - name: angular-config
+    files:
+      # Complete copy of k8s/config.yml plus the themes[].headTags block.
+      - config.yml
+  - name: seed-testsite-css
+    files:
+      - seed-testsite.css
 #images:
 #  - name: dataquest/dspace
 #    newName: ufal/dspace

--- a/overlays/kosarko-ns/seed-testsite.css
+++ b/overlays/kosarko-ns/seed-testsite.css
@@ -1,0 +1,75 @@
+/*
+ * Test-site branding override.
+ *
+ * Loaded via themes[].headTags in config.yml, which ThemeService renders as a
+ * <link rel="stylesheet" class="theme-head-tag"> in <head> -- server-side, so it
+ * is present in the initial SSR HTML, not only after hydration.
+ *
+ * Deliberately CSS-only. The header/footer are compiled-in Angular components
+ * (prebuilt image dataquest/dspace-angular:dspace-7_x), so overriding them
+ * properly would mean a fork rebuild. Hiding + pseudo-elements needs neither,
+ * and a pseudo-element is not a DOM node, so Angular hydration cannot reconcile
+ * it away.
+ *
+ * Selectors come from the templates, verified against the live DOM:
+ *   header: src/themes/dspace/app/header/header.component.html
+ *           <header class="header"> = <ds-clarin-navbar-top> + .lindat-common-header
+ *   footer: src/app/footer/footer.component.html   (the dspace theme has NO footer
+ *           override -- the live element reports data-used-theme="base")
+ *
+ * !important throughout: the theme bundle (dspace-theme.css) loads from the same
+ * <head> and we cannot rely on winning source order.
+ */
+
+:root {
+  --seed-test-bg: #8a2b06;
+  --seed-test-fg: #fff8f0;
+  --seed-test-accent: #ffb300;
+}
+
+/* ------------------------------------------------------------------ HEADER --
+ * Keep <ds-clarin-navbar-top> (language flags + login/logout badge) exactly as
+ * it is. Replace only the LINDAT/CLARIAH navigation block with a demo banner.
+ */
+ds-header header.header .lindat-common-header {
+  display: none !important;
+}
+
+ds-header header.header::after {
+  content: "DEMO / TEST INSTANCE \2014 \00a0 synthetic data only, nothing here is a real resource";
+  display: block !important;
+  padding: 0.85rem 1rem !important;
+  background: repeating-linear-gradient(
+    45deg,
+    var(--seed-test-bg),
+    var(--seed-test-bg) 18px,
+    #7a2605 18px,
+    #7a2605 36px
+  ) !important;
+  border-bottom: 3px solid var(--seed-test-accent) !important;
+  color: var(--seed-test-fg) !important;
+  font-weight: 700 !important;
+  font-size: 1.05rem !important;
+  letter-spacing: 0.04em !important;
+  text-align: center !important;
+  text-transform: uppercase !important;
+}
+
+/* ------------------------------------------------------------------ FOOTER --
+ * Drop the whole LINDAT/CLARIAH footer (partner lists, badges, funding
+ * acknowledgement, external links) and leave a single centered line.
+ */
+ds-footer footer .lindat-common-footer {
+  display: none !important;
+}
+
+ds-footer footer.text-lg-start::after {
+  content: "Visible CLARIN-DSpace test site \2014 \00a0 synthetic corpus, no real data, no real authors";
+  display: block !important;
+  padding: 1.75rem 1rem !important;
+  background: var(--seed-test-bg) !important;
+  border-top: 3px solid var(--seed-test-accent) !important;
+  color: var(--seed-test-fg) !important;
+  font-weight: 600 !important;
+  text-align: center !important;
+}


### PR DESCRIPTION
This pull request introduces a test-site visual override to the Angular frontend deployment, ensuring clear test-site branding without impacting backend services or requiring an Angular image rebuild. The changes add a new stylesheet and configuration for the test environment, update deployment manifests to mount these as separate ConfigMaps, and document the rationale for this separation to avoid unnecessary backend restarts.

**Test-site branding and configuration:**

* Added a new `seed-testsite.css` stylesheet that visually marks the site as a test/demo instance by modifying the header and footer, using prominent banners and colors.
* Updated `config.yml` to add a `themes[].headTags` block, injecting a `noindex` robots meta tag and linking the new stylesheet to ensure search engines do not index the site and the test branding is always visible.

**Deployment and configuration management:**

* Modified `angular-deployment.yaml` to mount the new stylesheet and config as separate volumes in the Angular container, ensuring these changes only affect the frontend pod and not the backend.
* Updated `kustomization.yaml` to generate distinct ConfigMaps for the frontend's `config.yml` and the test-site stylesheet, preventing backend pod restarts on purely cosmetic frontend changes.