### PR TITLE
kosarko-ns: override robots.txt to disallow all crawling

### DIFF
--- a/overlays/kosarko-ns/angular-deployment.yaml
+++ b/overlays/kosarko-ns/angular-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         - name: angular-config
           configMap:
             name: angular-config
+        - name: robots-txt-ejs
+          configMap:
+            name: robots-txt-ejs
       containers:
         - name: dspace-angular
           env:
@@ -38,3 +41,11 @@ spec:
             - name: angular-config
               mountPath: /app/config/config.yml
               subPath: config.yml
+            # REPLACE the stock robots.txt template. This is the copy Express
+            # actually renders: views root is dist/browser, so the dist/server
+            # copy of the same file is never read. See kustomization.yaml for
+            # why this is needed on top of the noindex meta tag, and why a pod
+            # restart (which the generator hash triggers) is part of the deal.
+            - name: robots-txt-ejs
+              mountPath: /app/dist/browser/assets/robots.txt.ejs
+              subPath: robots.txt.ejs

--- a/overlays/kosarko-ns/kustomization.yaml
+++ b/overlays/kosarko-ns/kustomization.yaml
@@ -36,6 +36,47 @@ configMapGenerator:
   - name: seed-testsite-css
     files:
       - seed-testsite.css
+  # ---------------------------------------------------------------------------
+  # robots.txt: keep this test instance out of search.
+  #
+  # The driver is the SITEMAP, not the meta tag. Stock robots.txt advertises two
+  # `Sitemap:` lines and a backend cron regenerates sitemap0.xml nightly
+  # (5 <loc>, lastmod 2026-07-30T01:15Z) -- an active invitation that grows with
+  # every seeded item, and one no amount of meta-tag coverage removes.
+  #
+  # It also covers what the meta tag structurally cannot: themes[].headTags
+  # injects <meta name="robots" content="noindex, nofollow"> during SSR, so the
+  # tag is absent from every universal.excludePathPatterns route -- /search,
+  # /browse/, /community-list, /statistics, /notifications, /access-control and
+  # the uuid-scoped browse routes serve a bare CSR shell where it appears only
+  # after hydration. That list is compiled into the image's
+  # environment.production.ts -- NOT in this repo and NOT in the config.yml we
+  # mount over it -- so it can move on any image bump with nothing here to
+  # review. Verified live 2026-07-30 (`/search/foo` is excluded too: the
+  # compiled pattern is `^/search`, unanchored).
+  #
+  # `Disallow: /` SUPERSEDES the meta tag for compliant crawlers rather than
+  # complementing it: a disallowed URL is never fetched, so the tag is never
+  # read. The tag stays as the fallback for crawlers that ignore robots.txt.
+  # Consequence: this freezes rather than removes -- anything already indexed
+  # needs a manual removal request.
+  #
+  # Replacing the whole template is both forced and smaller: subPath mounts a
+  # file entire and kustomize cannot patch generated file content, so merely
+  # uncommenting the stock `Disallow: /browse/*` would mean vendoring 153
+  # upstream lines into this overlay, to then drift on every image bump.
+  #
+  # A RESTART is required. subPath ConfigMap mounts are not live-updated by
+  # kubelet, and each of the container's 7 pm2 workers caches the compiled
+  # template for its lifetime (observed: after restoring the file on disk, ~6/7
+  # of responses still served the edited version). The generator's name-suffix
+  # hash is what rolls dspace-angular, and only dspace-angular per the split
+  # above -- do not add disableNameSuffixHash. Verify once the rollout has
+  # completed: zero `Sitemap:` lines.
+  # ---------------------------------------------------------------------------
+  - name: robots-txt-ejs
+    files:
+      - robots.txt.ejs
 #images:
 #  - name: dataquest/dspace
 #    newName: ufal/dspace

--- a/overlays/kosarko-ns/robots.txt.ejs
+++ b/overlays/kosarko-ns/robots.txt.ejs
@@ -1,0 +1,10 @@
+# ok-dspace is a TEST instance. It contains synthetic data and is not a
+# repository of record, so nothing here should be crawled or indexed.
+#
+# Rendered by dspace-angular's Express server (server.ts, GET /robots.txt).
+# The stock template it replaces is dspace-angular's src/robots.txt.ejs; the
+# `origin` template variable it offers is deliberately unused here, since the
+# sitemap advertisements are exactly what this override drops.
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
ok-dspace is a test instance holding synthetic data. Two things make it discoverable today:

1. **The sitemap is live and regenerating.** Stock `robots.txt` advertises two `Sitemap:` lines, and a backend cron rebuilds `sitemap0.xml` nightly (`lastmod 2026-07-30T01:15:00Z`, 5 `<loc>` entries). That is an active invitation, and it grows with every item seeded.
2. **The `noindex` meta tag cannot reach every route.** `themes[].headTags` injects it during SSR, so it is absent from every route in `universal.excludePathPatterns` — `/search`, `/browse/`, `/community-list`, `/statistics`, `/notifications`, `/access-control` and the uuid-scoped browse routes serve a bare CSR shell where the tag only appears after hydration. Verified live: `/` and `/collections` carry the tag, those do not.

That exclusion list is compiled into the image (`environment.production.ts`), not held in this repo — the `config.yml` this overlay mounts omits `universal.excludePathPatterns`, so the compiled array survives. It can therefore change on any image bump with nothing here to review, which is the main argument for a blanket rule over enumerating paths.

## What this does

Mounts a 10-line `robots.txt.ejs` (`User-agent: *` / `Disallow: /`, no `Sitemap:` lines) over `/app/dist/browser/assets/robots.txt.ejs` via a ConfigMap `subPath` — the same mechanism already used for `config.yml`, `environment.prod.ts` and `seed-testsite.css`. No image rebuild, namespace-level permissions only.

Note the relationship to the meta tag: for a compliant crawler `Disallow: /` **supersedes** it rather than complementing it, since a disallowed URL is never fetched and the tag never read. The tag remains the fallback for crawlers that ignore robots.txt. Consequence: this freezes rather than removes, so anything already indexed would need a manual removal request.

Whole-file replacement is both forced and smaller: `subPath` mounts a file entire and kustomize cannot patch generated file content, so merely uncommenting the stock `Disallow: /browse/*` would mean vendoring all 153 upstream lines into this overlay.

## Verification

- `kubectl kustomize overlays/kosarko-ns` builds; rendered output diffed against the same build from pristine `main`. **Only the new ConfigMap and the `dspace-angular` Deployment change** — `local-config-map` keeps its hash, so the backend does not bounce.
- Applied for real on a local k3s stack from this same file: `/robots.txt` served the override with zero `Sitemap:` lines, `assets/` was not shadowed (`seed-testsite.css` and `config.json` still 200), homepage still 200 with its robots meta. Then fully reverted.
- No new kind is rendered, so `ci-reconcile/role.yaml` still covers the overlay (that file asks for this check).
- `yq 4.53.3` round-trips the edited `kustomization.yaml` byte-identically, so the next `pin-ok-dspace` run still produces a one-line tag diff.

## Two gotchas, both documented in the overlay

- The rendered template is the **`dist/browser`** copy. The image carries it at `dist/server` too, but `server.ts` sets Express `views` to `dist/browser`, so mounting the server path would be a silent no-op. Established by marking both copies in a running pod.
- **A restart is required.** `subPath` ConfigMap mounts are not live-updated by kubelet, and the container runs `pm2-runtime` with 7 workers that each cache the compiled template for their lifetime (observed: after restoring the file on disk, ~6/7 of responses still served the edited version). The generator name-suffix hash is what rolls the pods — do not add `disableNameSuffixHash`.

Verify after the reconciler's rollout completes: `/robots.txt` should carry zero `Sitemap:` lines.

## Out of scope

OAI-PMH is separately reachable and harvesters do not consult `robots.txt`. Tracked separately.