### PR TITLE
kosarko-ns: stop the OAI endpoint claiming to be the LINDAT/UFAL archive

### DIFF
--- a/overlays/kosarko-ns/local.cfg
+++ b/overlays/kosarko-ns/local.cfg
@@ -80,3 +80,23 @@ spring.servlet.multipart.max-request-size = 10GB
 #authority.controlled.dc.publisher = true
 #
 #ror.api-url = https://api.ror.org/v2/organizations
+
+# ---------------------------------------------------------------------------
+# OAI-PMH: drop the OLAC institutional-archive description.
+# description-olac.xml is a template but oai.cfg contains lindat specific defaults.
+# We could use the template variables, but we rather disable the extra description.
+#
+# Pointing description.file.1 at a path that does not exist drops the block:
+# DSpaceRepositoryConfiguration.getDescription() skips any entry whose File
+# does not exist, and stops the indexed scan only on a NULL property -- so an
+# absent file is skipped while description.file.0 (description.xml, the generic
+# oai-identifier block) is still served. Blanking the eight description.*
+# values individually would work too, but leaves an OLAC record asserting this
+# is an institutional archive; there is no reason for a test instance to claim
+# that at all.
+#
+# NOTE: robots.txt cannot help here -- harvesters do not consult it. This is
+# also why this change bounces the BACKEND (local.cfg is in local-config-map),
+# unlike the frontend-only robots.txt override.
+# ---------------------------------------------------------------------------
+oai.description.file.1 = ${dspace.dir}/config/crosswalks/oai/description-olac.disabled.xml


### PR DESCRIPTION
/server/oai/request?verb=Identify currently serves an OLAC institutional archive description that identifies this test instance as LINDAT/UFAL.

Those values are correct for the real LINDAT instance and live in the image at config/modules/oai.cfg, so the override belongs in this overlay rather than in the fork. Pointing oai.description.file.1 at a nonexistent path drops the block: DSpaceRepositoryConfiguration.getDescription() skips entries whose File does not exist and stops the indexed scan only on a null property, so description.file.0 (the generic oai-identifier block) is still served.